### PR TITLE
Pyramid clipping test

### DIFF
--- a/napari/_vispy/_tests/test_vispy_big_images.py
+++ b/napari/_vispy/_tests/test_vispy_big_images.py
@@ -25,27 +25,17 @@ def test_really_big_2d_image(viewer_factory):
 
     # Screenshot pixel coordinates to test (in format: row, column)
     center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
-    top_left_corner = [40, 36]
-    top_right_corner = [40, 763]
-    bottom_left_corner = [screenshot.shape[0] - 40, 36]
-    bottom_right_corner = [screenshot.shape[0] - 40, 763]
+    top_left = [40, 36]
+    top_right = [40, 763]
+    bottom_left = [screenshot.shape[0] - 40, 36]
+    bottom_right = [screenshot.shape[0] - 40, 763]
 
     expected_value = np.array([255, 255, 255, 255])  # white pixel value
     assert all(screenshot[center_coord[0], center_coord[1]] == expected_value)
-    assert all(
-        screenshot[top_left_corner[0], top_left_corner[1]] == expected_value
-    )
-    assert all(
-        screenshot[top_right_corner[0], top_right_corner[1]] == expected_value
-    )
-    assert all(
-        screenshot[bottom_left_corner[0], bottom_left_corner[1]]
-        == expected_value
-    )
-    assert all(
-        screenshot[bottom_right_corner[0], bottom_right_corner[1]]
-        == expected_value
-    )
+    assert all(screenshot[top_left[0], top_left[1]] == expected_value)
+    assert all(screenshot[top_right[0], top_right[1]] == expected_value)
+    assert all(screenshot[bottom_left[0], bottom_left[1]] == expected_value)
+    assert all(screenshot[bottom_right[0], bottom_right[1]] == expected_value)
 
 
 def test_big_3D_image(viewer_factory):

--- a/napari/_vispy/_tests/test_vispy_big_images.py
+++ b/napari/_vispy/_tests/test_vispy_big_images.py
@@ -15,6 +15,39 @@ def test_big_2D_image(viewer_factory):
         assert np.all(layer._transforms['tile2data'].scale == s)
 
 
+def test_really_big_2d_image(viewer_factory):
+    view, viewer = viewer_factory(show=True)
+
+    shape = (6898, 9946)
+    data = np.ones(shape)
+    _ = viewer.add_image(data)
+    screenshot = viewer.screenshot()
+
+    # Screenshot pixel coordinates to test (in format: row, column)
+    center_coord = np.round(np.array(screenshot.shape[:2]) / 2).astype(np.int)
+    top_left_corner = [40, 36]
+    top_right_corner = [40, 763]
+    bottom_left_corner = [screenshot.shape[0] - 40, 36]
+    bottom_right_corner = [screenshot.shape[0] - 40, 763]
+
+    expected_value = np.array([255, 255, 255, 255])  # white pixel value
+    assert all(screenshot[center_coord[0], center_coord[1]] == expected_value)
+    assert all(
+        screenshot[top_left_corner[0], top_left_corner[1]] == expected_value
+    )
+    assert all(
+        screenshot[top_right_corner[0], top_right_corner[1]] == expected_value
+    )
+    assert all(
+        screenshot[bottom_left_corner[0], bottom_left_corner[1]]
+        == expected_value
+    )
+    assert all(
+        screenshot[bottom_right_corner[0], bottom_right_corner[1]]
+        == expected_value
+    )
+
+
 def test_big_3D_image(viewer_factory):
     """Test big 3D image with axis exceeding max texture size."""
     view, viewer = viewer_factory(ndisplay=3)


### PR DESCRIPTION
Hi Nick, here's a test you could use to do screenshot introspection.

Two things:
1. The pixel coordinates inspected for `top_left`, `top_right`, `bottom_left`, & `bottom_right` are arbitrary & what worked with my screen size & resolution. I think you had a much better way to calculate those positions though, so we should replace the hard coded numbers with that. Then the test should be more robust on the CI (I haven't tried to run the CI, I've only run pytest locally)
2. When Talley's canvas render PR https://github.com/napari/napari/pull/1109 goes through, this test should get updated. But I'm sure you don't want to put your PR entirely on hold for that, so this will do in the meantime.
