### PR TITLE
Refactored csv reading

### DIFF
--- a/napari/conftest.py
+++ b/napari/conftest.py
@@ -1,4 +1,5 @@
 import warnings
+from functools import partial
 from typing import List
 
 import numpy as np
@@ -119,14 +120,14 @@ def layer_writer_and_data(request):
         layer = Points(data)
         writer = napari_write_points
         extension = '.csv'
-        reader = io.read_points_csv
+        reader = partial(io.csv_to_layer_data, require_type='points')
     elif request.param == 'points-with-properties':
         data = np.random.rand(20, 2)
         Layer = Points
         layer = Points(data, properties={'values': np.random.rand(20)})
         writer = napari_write_points
         extension = '.csv'
-        reader = io.read_points_csv
+        reader = partial(io.csv_to_layer_data, require_type='points')
     elif request.param == 'shapes':
         np.random.seed(0)
         data = [
@@ -141,7 +142,7 @@ def layer_writer_and_data(request):
         layer = Shapes(data, shape_type=shape_type)
         writer = napari_write_shapes
         extension = '.csv'
-        reader = io.read_shapes_csv
+        reader = partial(io.csv_to_layer_data, require_type='shapes')
     else:
         return None, None, None, None, None
 

--- a/napari/plugins/_builtins.py
+++ b/napari/plugins/_builtins.py
@@ -9,6 +9,7 @@ import numpy as np
 from napari_plugin_engine import napari_hook_implementation
 
 from ..types import (
+    LayerData,
     FullLayerData,
     ReaderFunction,
     WriterFunction,
@@ -19,9 +20,22 @@ from ..utils.io import (
     magic_imread,
     write_csv,
     imsave_extensions,
-    read_csv_layer_data,
+    csv_to_layer_data,
 )
 from ..utils.misc import abspath_or_url
+
+
+def csv_reader_function(path: Union[str, List[str]]) -> List[LayerData]:
+    if isinstance(path, list):
+        out: List[LayerData] = []
+        for p in path:
+            layer_data = csv_to_layer_data(p, require_type=None)
+            if layer_data:
+                out.append(layer_data)
+        return out
+    else:
+        layer_data = csv_to_layer_data(path, require_type=None)
+        return [layer_data] if layer_data else []
 
 
 @napari_hook_implementation(trylast=True)
@@ -42,7 +56,7 @@ def napari_get_reader(path: Union[str, List[str]]) -> ReaderFunction:
         function that returns layer_data to be handed to viewer._add_layer_data
     """
     if isinstance(path, str) and path.endswith('.csv'):
-        return read_csv_layer_data
+        return csv_reader_function
     return image_reader_to_layerdata_reader(magic_imread)
 
 

--- a/napari/utils/_tests/test_io.py
+++ b/napari/utils/_tests/test_io.py
@@ -195,7 +195,7 @@ def test_read_csv(tmpdir):
     assert os.path.exists(expected_filename)
 
     # Read csv file
-    read_data, read_column_names = io.read_csv(expected_filename)
+    read_data, read_column_names, _ = io.read_csv(expected_filename)
     read_data = np.array(read_data).astype('float')
     np.testing.assert_allclose(expected_data, read_data)
 


### PR DESCRIPTION
hey @sofroniewn 
lots of changes here, so I didn't want to push directly on top of your PR.  You can consider them here.  I got frustrated that we were reading files and checking headers and stuff in a lot of different places.  So I tried to centralize the logic into two main functions that minimize file IO.  (these are the only two functions someone should need to use directly).

- `napari.utils.io.read_csv`: takes a CSV and returns (data, column_names, layer_type).  It accepts a `require_type` argument that, if not `None` will raise an exception if the data file doesn't match one of the recognized formats.  (pass `"any"` to ensure that it is at least one of the valid formats).

- `napari.utils.io.csv_to_layer_data`: wraps the previous function, but returns data in `LayerData` format by handing the data to the appropriate `_<layer_type>_to_layerdata` function.  Also accepts `require_type` that will raise an exception if not `None` and data is not recognized.

the equivalent of your previous `read_points_csv` is now `csv_to_layer_data(path, require_type='points')`

let me know what you think...