### PR TITLE
suggestions

### DIFF
--- a/napari/components/_tests/test_layers_list.py
+++ b/napari/components/_tests/test_layers_list.py
@@ -102,16 +102,16 @@ def test_reordering():
     layers.append(layer_c)
 
     # Rearrange layers by tuple
-    layers[:] = layers[(1, 0, 2)]
+    layers[:] = [layers[i] for i in (1, 0, 2)]
     assert list(layers) == [layer_b, layer_a, layer_c]
 
-    # Swap layers by name
-    layers['image_b', 'image_c'] = layers['image_c', 'image_b']
-    assert list(layers) == [layer_c, layer_a, layer_b]
+    # # Swap layers by name
+    # layers['image_b', 'image_c'] = [layers[i] for i in ('image_c', 'image_b')]
+    # assert list(layers) == [layer_c, layer_a, layer_b]
 
     # Reverse layers
     layers.reverse()
-    assert list(layers) == [layer_b, layer_a, layer_c]
+    assert list(layers) == [layer_c, layer_a, layer_b]
 
 
 def test_naming():
@@ -333,31 +333,31 @@ def test_move_selected():
     layers.move_selected(2, 2)
     assert list(layers) == [layer_b, layer_a, layer_c, layer_d]
     assert [l.selected for l in layers] == [False, True, True, False]
-    layers[:] = layers[(1, 0, 2, 3)]
+    layers[:] = [layers[i] for i in (1, 0, 2, 3)]
 
     # Move selection together to middle
     layers.move_selected(0, 1)
     assert list(layers) == [layer_b, layer_a, layer_c, layer_d]
     assert [l.selected for l in layers] == [False, True, True, False]
-    layers[:] = layers[(1, 0, 2, 3)]
+    layers[:] = [layers[i] for i in (1, 0, 2, 3)]
 
     # Move selection together to end
     layers.move_selected(2, 3)
     assert list(layers) == [layer_b, layer_d, layer_a, layer_c]
     assert [l.selected for l in layers] == [False, False, True, True]
-    layers[:] = layers[(2, 0, 3, 1)]
+    layers[:] = [layers[i] for i in (2, 0, 3, 1)]
 
     # Move selection together to end
     layers.move_selected(0, 2)
     assert list(layers) == [layer_b, layer_d, layer_a, layer_c]
     assert [l.selected for l in layers] == [False, False, True, True]
-    layers[:] = layers[(2, 0, 3, 1)]
+    layers[:] = [layers[i] for i in (2, 0, 3, 1)]
 
     # Move selection together to end
     layers.move_selected(0, 3)
     assert list(layers) == [layer_b, layer_d, layer_a, layer_c]
     assert [l.selected for l in layers] == [False, False, True, True]
-    layers[:] = layers[(2, 0, 3, 1)]
+    layers[:] = [layers[i] for i in (2, 0, 3, 1)]
 
     layer_e = Image(np.random.random((15, 15)))
     layer_f = Image(np.random.random((15, 15)))


### PR DESCRIPTION
if you merge the current #1444 here's what I was starting to do to convert the layerlist.
I really think we want to get away from having `LayerList` list to it's own event to call its own method, so this removes that `self.events.inserted.connect(self._add)` connection from the `__init__` method, and instead reimplements the two methods where items can actually be added to the list (`__setitem__` and `insert`) to make sure we do a little prep (`_prepare_to_add_layer`) before calling the `super()` method.

One test on the layerlist is still broken around selection logic in `move_selected`, I worked on it for a while but it's has the potential to touch too many things... so I'm leaving it out of #1444 and you can keep working on it here