### PR TITLE
Add benchmarking for qt vectors refresh

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -51,4 +51,5 @@ jobs:
           external_repository: napari/napari.github.io
           publish_dir: docs/_build
           publish_branch: gh-pages
+          destination_dir: dev
           cname: napari.org

--- a/.github/workflows/docker-singularity-publish.yml
+++ b/.github/workflows/docker-singularity-publish.yml
@@ -86,16 +86,13 @@ jobs:
           file: "dockerfile"
           target: ${{ matrix.target }}
 
-      - name: Check out code for the container build
-        uses: actions/checkout@v2
-
-  # ----
+# ----
 
   build2:
     needs: build1
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/truatpasteurdotfr/docker-c7-singularity-builder:main
+      image: quay.io/singularity/docker2singularity:v3.10.0
       options: --privileged
     permissions:
       contents: read

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,5 @@
-FROM --platform=linux/amd64 ubuntu:20.04 AS napari
+FROM --platform=linux/amd64 ubuntu:22.04 AS napari
+
 
 # below env var required to install libglib2.0-0 non-interactively
 ENV TZ=America/Los_Angeles
@@ -8,7 +9,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -qqy  \
         build-essential \
-        python3.8 \
+        python3.9 \
         python3-pip \
         git \
         mesa-utils \
@@ -27,10 +28,13 @@ RUN apt-get update && \
         libxcb-xinerama0 \
         libxcb-xinput0 \
         libxcb-xfixes0 \
-        libxcb-shape0
+        libxcb-shape0 \
+        && apt-get clean
 
 # install napari release version
 RUN pip3 install napari[all]
+
+# copy examples
 COPY examples /tmp/examples
 
 ENTRYPOINT ["python3", "-m", "napari"]

--- a/docs/_static/redirects.js
+++ b/docs/_static/redirects.js
@@ -1,0 +1,11 @@
+// Will match any urls containing the strings
+// - "/dev/"
+// - "/stable/"
+// - "/X.Y.Z/"
+// where X.Y.Z is a version string and redirect the page to its stable version.
+
+let pattern = /\/dev\/|\/stable\/|\/\d+.\d+.\d+\//;
+
+if (!pattern.test(window.location.href.toLowerCase())) {
+   window.location.href = 'http://napari.org/stable'+window.location.pathname;
+}

--- a/docs/_static/version_switcher.json
+++ b/docs/_static/version_switcher.json
@@ -1,29 +1,17 @@
 [
 	{
-	  "version": "dev"
+		"name": "latest",
+		"version": "dev",
+		"url": "https://napari.org/dev/"
 	},
 	{
-	  "version": "0.4.7"
-	},
+		"name": "stable",
+		"version": "0.4.16",
+		"url": "https://napari.org/stable/"
+	}
 	{
-	  "version": "0.4.6"
-	},
-	{
-	  "version": "0.4.5"
-	},
-	{
-	  "version": "0.4.4"
-	},
-	{
-	  "version": "0.4.3"
-	},
-	{
-	  "version": "0.4.0"
-	},
-	{
-	  "version": "0.3.8"
-	},
-	{
-	  "version": "0.3.7"
-	},
+		"name": "0.4.15",
+		"version": "0.4.15",
+		"url": "https://napari.org/0.4.15/"
+	}
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,13 +71,26 @@ external_toc_exclude_missing = False
 # a list of builtin themes.
 #
 html_theme = 'napari'
+
+# Define the json_url for our version switcher.
+json_url = "https://napari.org/version_switcher.json"
+
+if version == "dev":
+    version_match = "latest"
+else:
+    version_match = release
+
 html_theme_options = {
     "external_links": [
         {"name": "napari hub", "url": "https://napari-hub.org"}
     ],
     "github_url": "https://github.com/napari/napari",
     "navbar_start": ["navbar-project"],
-    "navbar_end": ["navbar-icon-links"],
+    "navbar_end": ["version-switcher", "navbar-icon-links"],
+    "switcher": {
+        "json_url": "https://napari.org/version_switcher.json",
+        "version_match": version_match,
+    },
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,
@@ -90,6 +103,10 @@ html_title = 'napari'
 
 html_css_files = [
     'custom.css',
+]
+
+html_js_files = [
+    'redirects.js',
 ]
 
 intersphinx_mapping = {

--- a/docs/guides/magicgui.md
+++ b/docs/guides/magicgui.md
@@ -205,6 +205,7 @@ each type is described below:
 - any of the `<LayerType>Data` types from {mod}`napari.types`, such as
   {attr}`napari.types.ImageData` or  {attr}`napari.types.LabelsData`
 - {attr}`napari.types.LayerDataTuple`
+- `List`s of {class}`napari.layers.Layer` or {attr}`napari.types.LayerDataTuple`
 
 ### Returning a `Layer` subclass
 
@@ -250,6 +251,27 @@ nbscreenshot(viewer, alt_text="A magicgui widget using an image layer return ann
 With this method, a new layer will be added to the layer list each time the
 function is called.  To update an existing layer, you must use the
 `LayerDataTuple` approach described below
+```
+
+### Returning `List[napari.layers.Layer]`
+
+You can create multiple layers by returning a list of
+{class}`~napari.layers.Layer`.
+
+```python
+from typing import List
+
+@magicgui
+def make_points(...) -> List[napari.layers.Layer]:
+  ...
+```
+
+```{note}
+Note: the `List[]` syntax here is optional from the perspective of `napari`.  You
+can return either a single Layer or a list of Layers and they will all be added
+to the viewer as long as you use either `List[napari.layers.Layer]` or 
+`napari.layers.Layer`.  If you want your code to be properly typed, however,
+your return type must match your return annotation.
 ```
 
 (returning-napari-types-data)=

--- a/docs/howtos/layers/image.md
+++ b/docs/howtos/layers/image.md
@@ -293,3 +293,13 @@ can.
 
 Currently if you pass contrast limits as a keyword argument to a layer then full
 extent of the contrast limits range slider will be set to those values.
+
+## Saving without image compression
+
+When saving an image layer, lossless zlib compression is applied by default. 
+ To save with a different level of compression, consider using 
+ [imageio.imwrite](https://imageio.readthedocs.io/en/stable/_autosummary/imageio.v3.imwrite.html).  
+Adjusting compression can be accomplished by including the appropriate kwargs 
+as outlined in the following locations for 
+[tiff](https://imageio.readthedocs.io/en/stable/_autosummary/imageio.plugins.tifffile.html#metadata-for-writing) or 
+[png](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#png) files. 

--- a/docs/howtos/layers/labels.md
+++ b/docs/howtos/layers/labels.md
@@ -113,6 +113,18 @@ layer button above the layers list. The shape of the new labels layer will match
 the size of any currently existing image layers, allowing you to paint on top of
 them.
 
+```{admonition} Want to save without compression?
+:class: tip
+
+When saving a labels layer, lossless zlib compression is applied by default. 
+ To save with a different level of compression, consider using 
+[imageio.imwrite](https://imageio.readthedocs.io/en/stable/_autosummary/imageio.v3.imwrite.html).  
+Adjusting compression can be accomplished by including the appropriate kwargs 
+as outlined in the following locations for 
+[tiff](https://imageio.readthedocs.io/en/stable/_autosummary/imageio.plugins.tifffile.html#metadata-for-writing) or 
+[png](https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#png) files. 
+```
+
 ## Non-editable mode
 
 If you want to disable editing of the labels layer you can set the `editable`

--- a/docs/plugins/find_and_install_plugin.md
+++ b/docs/plugins/find_and_install_plugin.md
@@ -25,8 +25,17 @@ directly from within napari:
 
    ![napari viewer's Plugins menu with Install/Uninstall Plugins as thr first item.](/images/plugin-menu.png)
 
-2. In the resulting window that opens, where it says “Install by name/URL”, type the name of the plugin you want to install.
+2. In the resulting window that opens, where it says “Install by name/URL”,
+    enter the name of the plugin you want to install (or *any* valid pip
+    [requirement
+    specifier](https://pip.pypa.io/en/stable/reference/requirement-specifiers/)
+    or [VCS scheme](https://pip.pypa.io/en/stable/topics/vcs-support))
+
 
    ![napari viewer's Plugin dialog. At the bottom of the dialog, there is a place to install by name, URL, or dropping in a file.](/images/plugin-install-dialog.png)
+
+   ```{admonition} Example
+   If you want to install `napari-svg` directly from the development branch on the [github repository](https://github.com/napari/napari-svg), enter `git+https://github.com/napari/napari-svg.git` in the text field.
+   ```
 
 3. Click the “Install” button next to the input bar.

--- a/napari/_lazy.py
+++ b/napari/_lazy.py
@@ -44,7 +44,20 @@ def install_lazy(module_name, submodules=None, submod_attrs=None):
         if name in submodules:
             return import_module(f'{module_name}.{name}')
         elif name in attr_to_modules:
-            submod = import_module(f'{module_name}.{attr_to_modules[name]}')
+            try:
+                submod = import_module(
+                    f'{module_name}.{attr_to_modules[name]}'
+                )
+            except AttributeError as er:
+                # if we want any useful error message to show
+                # (besides just "cannot import name...") then we need raise anything
+                # BUT an attribute error here, because the __getattr__ protocol will
+                # swallow that error.
+                raise ImportError(
+                    f'Failed to import {attr_to_modules[name]} from {module_name}. '
+                    'See cause above'
+                ) from er
+            # this is where we allow an attribute error to be raised.
             return getattr(submod, name)
         else:
             raise AttributeError(f'No {module_name} attribute {name}')

--- a/napari/_qt/layer_controls/_tests/test_qt_image_layer.py
+++ b/napari/_qt/layer_controls/_tests/test_qt_image_layer.py
@@ -11,7 +11,7 @@ def test_interpolation_combobox(qtbot):
     qtbot.addWidget(qtctrl)
     combo = qtctrl.interpComboBox
     opts = {combo.itemText(i) for i in range(combo.count())}
-    assert opts == {'bicubic', 'bilinear', 'kaiser', 'nearest', 'spline36'}
+    assert opts == {'bicubic', 'linear', 'kaiser', 'nearest', 'spline36'}
     # programmatically adding approved interpolation works
     layer.interpolation2d = 'lanczos'
     assert combo.findText('lanczos') == 5

--- a/napari/_qt/layer_controls/qt_image_controls.py
+++ b/napari/_qt/layer_controls/qt_image_controls.py
@@ -14,7 +14,6 @@ from superqt import QLabeledDoubleSlider
 from ...layers.image._image_constants import (
     ImageRendering,
     Interpolation,
-    Interpolation3D,
     VolumeDepiction,
 )
 from ...utils.action_manager import action_manager
@@ -192,7 +191,7 @@ class QtImageControls(QtBaseImageControls):
         text : str
             Interpolation mode used by vispy. Must be one of our supported
             modes:
-            'bessel', 'bicubic', 'bilinear', 'blackman', 'catrom', 'gaussian',
+            'bessel', 'bicubic', 'linear', 'blackman', 'catrom', 'gaussian',
             'hamming', 'hanning', 'hermite', 'kaiser', 'lanczos', 'mitchell',
             'nearest', 'spline16', 'spline36'
         """
@@ -336,11 +335,7 @@ class QtImageControls(QtBaseImageControls):
             self.planeThicknessLabel.show()
 
     def _update_interpolation_combo(self):
-        interp_names = (
-            Interpolation3D.keys()
-            if self.layer._ndisplay == 3
-            else [i.value for i in Interpolation.view_subset()]
-        )
+        interp_names = [i.value for i in Interpolation.view_subset()]
         interp = (
             self.layer.interpolation2d
             if self.layer._ndisplay == 2

--- a/napari/_qt/widgets/qt_viewer_buttons.py
+++ b/napari/_qt/widgets/qt_viewer_buttons.py
@@ -417,7 +417,7 @@ def _omit_viewer_args(constructor):
         if len(args) > 1 and not isinstance(args[1], str):
             warnings.warn(
                 trans._(
-                    "viewer argument is deprecated and should not be used"
+                    "viewer argument is deprecated since 0.4.14 and should not be used"
                 ),
                 category=FutureWarning,
                 stacklevel=2,
@@ -426,7 +426,7 @@ def _omit_viewer_args(constructor):
         if "viewer" in kwargs:
             warnings.warn(
                 trans._(
-                    "viewer argument is deprecated and should not be used"
+                    "viewer argument is deprecated since 0.4.14 and should not be used"
                 ),
                 category=FutureWarning,
                 stacklevel=2,

--- a/napari/_tests/test_magicgui.py
+++ b/napari/_tests/test_magicgui.py
@@ -161,6 +161,25 @@ def test_magicgui_add_layer(make_napari_viewer, LayerType, data, ndim):
     assert viewer.layers[0].source.widget == add_layer
 
 
+def test_magicgui_add_layer_list(make_napari_viewer):
+    viewer = make_napari_viewer()
+
+    @magicgui
+    def add_layer() -> List[Layer]:
+        a = Image(data=np.random.randint(0, 10, size=(10, 10)))
+        b = Labels(data=np.random.randint(0, 10, size=(10, 10)))
+        return [a, b]
+
+    viewer.window.add_dock_widget(add_layer)
+    add_layer()
+    assert len(viewer.layers) == 2
+    assert isinstance(viewer.layers[0], Image)
+    assert isinstance(viewer.layers[1], Labels)
+
+    assert viewer.layers[0].source.widget == add_layer
+    assert viewer.layers[1].source.widget == add_layer
+
+
 def test_magicgui_add_layer_data_tuple(make_napari_viewer):
     viewer = make_napari_viewer()
 

--- a/napari/_vendor/darkdetect/__init__.py
+++ b/napari/_vendor/darkdetect/__init__.py
@@ -4,7 +4,7 @@
 #  Distributed under the terms of the 3-clause BSD License.
 #-----------------------------------------------------------------------------
 
-__version__ = '0.7.0'
+__version__ = '0.7.1'
 
 import sys
 import platform

--- a/napari/_vendor/darkdetect/__main__.py
+++ b/napari/_vendor/darkdetect/__main__.py
@@ -1,0 +1,9 @@
+#-----------------------------------------------------------------------------
+#  Copyright (C) 2019 Alberto Sottile
+#
+#  Distributed under the terms of the 3-clause BSD License.
+#-----------------------------------------------------------------------------
+
+import darkdetect
+
+print('Current theme: {}'.format(darkdetect.theme()))

--- a/napari/_vendor/darkdetect/_linux_detect.py
+++ b/napari/_vendor/darkdetect/_linux_detect.py
@@ -5,7 +5,6 @@
 #-----------------------------------------------------------------------------
 
 import subprocess
-import typing
 
 def theme():
     # Here we just triage to GTK settings for now
@@ -29,7 +28,8 @@ def isDark():
 def isLight():
     return theme() == 'Light'
 
-def listener(callback: typing.Callable[[str], None]) -> None:
+# def listener(callback: typing.Callable[[str], None]) -> None:
+def listener(callback):
     with subprocess.Popen(
         ('gsettings', 'monitor', 'org.gnome.desktop.interface', 'gtk-theme'),
         stdout=subprocess.PIPE,

--- a/napari/_vendor/darkdetect/_mac_detect.py
+++ b/napari/_vendor/darkdetect/_mac_detect.py
@@ -6,7 +6,6 @@
 
 import ctypes
 import ctypes.util
-import typing
 
 try:
     # macOS Big Sur+ use "a built-in dynamic linker cache of all system-provided libraries"
@@ -70,5 +69,6 @@ def isDark():
 def isLight():
     return theme() == 'Light'
 
-def listener(callback: typing.Callable[[str], None]) -> None:
+#def listener(callback: typing.Callable[[str], None]) -> None:
+def listener(callback):
     raise NotImplementedError()

--- a/napari/_vendor/darkdetect/_windows_detect.py
+++ b/napari/_vendor/darkdetect/_windows_detect.py
@@ -2,7 +2,6 @@ from winreg import HKEY_CURRENT_USER as hkey, QueryValueEx as getSubkeyValue, Op
 
 import ctypes
 import ctypes.wintypes
-import typing
 
 advapi32 = ctypes.windll.advapi32
 
@@ -79,7 +78,8 @@ def isLight():
     if theme() is not None:
         return theme() == 'Light'
 
-def listener(callback: typing.Callable[[str], None]) -> None:
+#def listener(callback: typing.Callable[[str], None]) -> None:
+def listener(callback):
     hKey = ctypes.wintypes.HKEY()
     advapi32.RegOpenKeyExA(
         ctypes.wintypes.HKEY(0x80000001), # HKEY_CURRENT_USER

--- a/napari/_vispy/experimental/tiled_image_visual.py
+++ b/napari/_vispy/experimental/tiled_image_visual.py
@@ -123,7 +123,7 @@ class TiledImageVisual(Image):
         TextureAtlas2D
             The newly created texture atlas.
         """
-        interp = 'linear' if self._interpolation == 'bilinear' else 'nearest'
+        interp = 'linear' if self._interpolation == 'linear' else 'nearest'
         return TextureAtlas2D(
             tile_shape,
             SHAPE_IN_TILES,

--- a/napari/_vispy/visuals/volume.py
+++ b/napari/_vispy/visuals/volume.py
@@ -35,7 +35,7 @@ int detectAdjacentBackground(float val_neg, float val_pos)
 vec4 calculateCategoricalColor(vec4 betterColor, vec3 loc, vec3 step)
 {
     // Calculate color by incorporating ambient and diffuse lighting
-    vec4 color0 = $sample(u_volumetex, loc);
+    vec4 color0 = $get_data(loc);
     vec4 color1;
     vec4 color2;
     float val0 = colorToVal(color0);
@@ -48,22 +48,22 @@ vec4 calculateCategoricalColor(vec4 betterColor, vec3 loc, vec3 step)
 
     // calculate normal vector from gradient
     vec3 N; // normal
-    color1 = $sample( u_volumetex, loc+vec3(-step[0],0.0,0.0) );
-    color2 = $sample( u_volumetex, loc+vec3(step[0],0.0,0.0) );
+    color1 = $get_data(loc+vec3(-step[0],0.0,0.0));
+    color2 = $get_data(loc+vec3(step[0],0.0,0.0));
     val1 = colorToVal(color1);
     val2 = colorToVal(color2);
     N[0] = val1 - val2;
     n_bg_borders += detectAdjacentBackground(val1, val2);
 
-    color1 = $sample( u_volumetex, loc+vec3(0.0,-step[1],0.0) );
-    color2 = $sample( u_volumetex, loc+vec3(0.0,step[1],0.0) );
+    color1 = $get_data(loc+vec3(0.0,-step[1],0.0));
+    color2 = $get_data(loc+vec3(0.0,step[1],0.0));
     val1 = colorToVal(color1);
     val2 = colorToVal(color2);
     N[1] = val1 - val2;
     n_bg_borders += detectAdjacentBackground(val1, val2);
 
-    color1 = $sample( u_volumetex, loc+vec3(0.0,0.0,-step[2]) );
-    color2 = $sample( u_volumetex, loc+vec3(0.0,0.0,step[2]) );
+    color1 = $get_data(loc+vec3(0.0,0.0,-step[2]));
+    color2 = $get_data(loc+vec3(0.0,0.0,step[2]));
     val1 = colorToVal(color1);
     val2 = colorToVal(color2);
     N[2] = val1 - val2;
@@ -126,7 +126,7 @@ ISO_CATEGORICAL_SNIPPETS = dict(
             // Take the last interval in smaller steps
             vec3 iloc = loc - step;
             for (int i=0; i<10; i++) {
-                color = $sample(u_volumetex, iloc);
+                color = $get_data(iloc);
                 if (floatNotEqual(color.g, categorical_bg_value) ) {
                     // when the non-background value is reached
                     // calculate the color (apply lighting effects)

--- a/napari/benchmarks/benchmark_qt_viewer_vectors.py
+++ b/napari/benchmarks/benchmark_qt_viewer_vectors.py
@@ -7,6 +7,7 @@ from qtpy.QtWidgets import QApplication
 
 import napari
 
+
 class QtViewerViewVectorSuite:
     """Benchmarks for viewing vectors in the viewer."""
 

--- a/napari/benchmarks/benchmark_qt_viewer_vectors.py
+++ b/napari/benchmarks/benchmark_qt_viewer_vectors.py
@@ -1,0 +1,30 @@
+# See "Writing benchmarks" in the asv docs for more information.
+# https://asv.readthedocs.io/en/latest/writing_benchmarks.html
+# or the napari documentation on benchmarking
+# https://github.com/napari/napari/blob/main/docs/BENCHMARKS.md
+import numpy as np
+from qtpy.QtWidgets import QApplication
+
+import napari
+
+class QtViewerViewVectorSuite:
+    """Benchmarks for viewing vectors in the viewer."""
+
+    params = [2**i for i in range(4, 18, 2)]
+
+    def setup(self, n):
+        _ = QApplication.instance() or QApplication([])
+        np.random.seed(0)
+        self.data = np.random.random((n, 2, 3))
+        self.viewer = napari.Viewer()
+        self.layer = self.viewer.add_vectors(self.data)
+        self.visual = self.viewer.window._qt_viewer.layer_to_visual[self.layer]
+
+    def teardown(self, n):
+        self.viewer.window.close()
+
+    def time_vectors_refresh(self, n):
+        """Time to view a vector."""
+        self.viewer.layers[0].refresh()
+        self.viewer.layers[0].refresh()
+        self.viewer.layers[0].refresh()

--- a/napari/components/viewer_model.py
+++ b/napari/components/viewer_model.py
@@ -28,13 +28,17 @@ from ..errors import (
     NoAvailableReaderError,
     ReaderPluginError,
 )
-from ..layers import Image, Layer
+from ..layers import Image, Labels, Layer, Points, Shapes
 from ..layers._source import layer_source
 from ..layers.image._image_utils import guess_labels
+from ..layers.labels._labels_key_bindings import labels_fun_to_mode
+from ..layers.points._points_key_bindings import points_fun_to_mode
+from ..layers.shapes._shapes_key_bindings import shapes_fun_to_mode
 from ..layers.utils.stack_utils import split_channels
 from ..plugins.utils import get_potential_readers, get_preferred_reader
 from ..settings import get_settings
 from ..utils._register import create_func as create_add_method
+from ..utils.action_manager import action_manager
 from ..utils.colormaps import ensure_colormap
 from ..utils.context import Context, create_context
 from ..utils.events import Event, EventedModel, disconnect_events
@@ -483,6 +487,9 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
         layer.events.shear.connect(self._on_layers_change)
         layer.events.affine.connect(self._on_layers_change)
         layer.events.name.connect(self.layers._update_name)
+        if hasattr(layer.events, "mode"):
+            layer.events.mode.connect(self._on_layer_mode_change)
+        self._layer_help_from_mode(layer)
 
         # Update dims and grid model
         self._on_layers_change()
@@ -495,6 +502,40 @@ class ViewerModel(KeymapProvider, MousemapProvider, EventedModel):
             ranges = self.layers._ranges
             midpoint = [self.rounded_division(*_range) for _range in ranges]
             self.dims.set_point(range(len(ranges)), midpoint)
+
+    @staticmethod
+    def _layer_help_from_mode(layer: Layer):
+        """
+        Update layer help text base on layer mode.
+        """
+        layer_to_func_and_mode = {
+            Points: points_fun_to_mode,
+            Labels: labels_fun_to_mode,
+            Shapes: shapes_fun_to_mode,
+        }
+
+        help_li = []
+        shortcuts = get_settings().shortcuts.shortcuts
+
+        for fun, mode_ in layer_to_func_and_mode.get(layer.__class__, []):
+            if mode_ == layer.mode:
+                continue
+            action_name = f"napari:{fun.__name__}"
+            desc = action_manager._actions[action_name].description.lower()
+            help_li.append(
+                trans._(
+                    "use <{shortcut}> for {desc}",
+                    shortcut=shortcuts[action_name][0],
+                    desc=desc,
+                )
+            )
+
+        layer.help = ", ".join(help_li)
+
+    def _on_layer_mode_change(self, event):
+        self._layer_help_from_mode(event.source)
+        if (active := self.layers.selection.active) is not None:
+            self.help = active.help
 
     def _on_remove_layer(self, event):
         """Disconnect old layer events.

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -12,7 +12,11 @@ import magicgui as mgui
 import numpy as np
 
 from ...utils._dask_utils import configure_dask
-from ...utils._magicgui import add_layer_to_viewer, get_layers
+from ...utils._magicgui import (
+    add_layer_to_viewer,
+    add_layers_to_viewer,
+    get_layers,
+)
 from ...utils.events import EmitterGroup, Event
 from ...utils.events.event import WarningEmitter
 from ...utils.geometry import (
@@ -1779,3 +1783,6 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
                     layer_type=layer_type,
                 )
             ) from exc
+
+
+mgui.register_type(type_=List[Layer], return_callback=add_layers_to_viewer)

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1012,7 +1012,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
     def get_value(
         self,
-        position,
+        position: Tuple[float],
         *,
         view_direction: Optional[np.ndarray] = None,
         dims_displayed: Optional[List[int]] = None,
@@ -1024,7 +1024,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         Parameters
         ----------
-        position : tuple
+        position : tuple of float
             Position in either data or world coordinates.
         view_direction : Optional[np.ndarray]
             A unit vector giving the direction of the ray in nD world coordinates.
@@ -1604,7 +1604,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
     def get_status(
         self,
-        position: np.ndarray,
+        position: Tuple[float],
         *,
         view_direction: Optional[np.ndarray] = None,
         dims_displayed: Optional[List[int]] = None,
@@ -1615,7 +1615,7 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
 
         Parameters
         ----------
-        position : tuple
+        position : tuple of float
             Position in either data or world coordinates.
         view_direction : Optional[np.ndarray]
             A unit vector giving the direction of the ray in nD world coordinates.

--- a/napari/layers/base/base.py
+++ b/napari/layers/base/base.py
@@ -1559,28 +1559,27 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
         )
 
         # find the maximal data-axis-aligned bounding box containing all four
-        # canvas corners
+        # canvas corners and round them to ints
         data_bbox = np.stack(
             [np.min(data_corners, axis=0), np.max(data_corners, axis=0)]
         )
-        # round and clip the bounding box values
         data_bbox_int = np.stack(
             [np.floor(data_bbox[0]), np.ceil(data_bbox[1])]
         ).astype(int)
-        displayed_extent = self.extent.data[:, displayed_axes]
-        data_bbox_clipped = np.clip(
-            data_bbox_int, displayed_extent[0], displayed_extent[1]
-        )
 
         if self._ndisplay == 2 and self.multiscale:
             level, scaled_corners = compute_multiscale_level_and_corners(
-                data_bbox_clipped,
+                data_bbox_int,
                 shape_threshold,
                 self.downsample_factors[:, displayed_axes],
             )
-            corners = np.zeros((2, self.ndim))
-            corners[:, displayed_axes] = scaled_corners
-            corners = corners.astype(int)
+            corners = np.zeros((2, self.ndim), dtype=int)
+            # The corner_pixels attribute stores corners in the data
+            # space of the selected level. Using the level's data
+            # shape only works for images, but that's the only case we
+            # handle now and downsample_factors is also only on image layers.
+            max_coords = np.take(self.data[level].shape, displayed_axes)
+            corners[:, displayed_axes] = np.clip(scaled_corners, 0, max_coords)
             display_shape = tuple(
                 corners[1, displayed_axes] - corners[0, displayed_axes]
             )
@@ -1594,6 +1593,11 @@ class Layer(KeymapProvider, MousemapProvider, ABC):
                 self.refresh()
 
         else:
+            # The stored corner_pixels attribute must contain valid indices.
+            displayed_extent = self.extent.data[:, displayed_axes]
+            data_bbox_clipped = np.clip(
+                data_bbox_int, displayed_extent[0], displayed_extent[1]
+            )
             corners = np.zeros((2, self.ndim), dtype=int)
             corners[:, displayed_axes] = data_bbox_clipped
             self.corner_pixels = corners

--- a/napari/layers/image/_image_constants.py
+++ b/napari/layers/image/_image_constants.py
@@ -16,7 +16,7 @@ class Interpolation(StringEnum):
 
     BESSEL = auto()
     BICUBIC = auto()
-    BILINEAR = auto()
+    LINEAR = auto()
     BLACKMAN = auto()
     CATROM = auto()
     GAUSSIAN = auto()
@@ -34,18 +34,11 @@ class Interpolation(StringEnum):
     def view_subset(cls):
         return (
             cls.BICUBIC,
-            cls.BILINEAR,
+            cls.LINEAR,
             cls.KAISER,
             cls.NEAREST,
             cls.SPLINE36,
         )
-
-
-class Interpolation3D(StringEnum):
-    """INTERPOLATION: Vispy interpolation mode for volume rendering."""
-
-    LINEAR = auto()
-    NEAREST = auto()
 
 
 class Mode(StringEnum):

--- a/napari/layers/image/_tests/test_image.py
+++ b/napari/layers/image/_tests/test_image.py
@@ -323,10 +323,10 @@ def test_interpolation():
     with pytest.deprecated_call():
         assert layer.interpolation == 'bicubic'
 
-    layer.interpolation2d = 'bilinear'
-    assert layer.interpolation2d == 'bilinear'
+    layer.interpolation2d = 'linear'
+    assert layer.interpolation2d == 'linear'
     with pytest.deprecated_call():
-        assert layer.interpolation == 'bilinear'
+        assert layer.interpolation == 'linear'
 
 
 def test_colormaps():

--- a/napari/layers/image/_tests/test_multiscale.py
+++ b/napari/layers/image/_tests/test_multiscale.py
@@ -234,10 +234,10 @@ def test_interpolation():
     with pytest.deprecated_call():
         assert layer.interpolation == 'bicubic'
 
-    layer.interpolation2d = 'bilinear'
+    layer.interpolation2d = 'linear'
     with pytest.deprecated_call():
-        assert layer.interpolation == 'bilinear'
-    assert layer.interpolation2d == 'bilinear'
+        assert layer.interpolation == 'linear'
+    assert layer.interpolation2d == 'linear'
 
 
 def test_colormaps():

--- a/napari/layers/image/_tests/test_multiscale.py
+++ b/napari/layers/image/_tests/test_multiscale.py
@@ -432,3 +432,57 @@ def test_multiscale_data_protocol():
     assert layer.data.dtype == float
     assert layer.data.shape == shapes[0]
     assert isinstance(layer.data[0], np.ndarray)
+
+
+@pytest.mark.parametrize(
+    ('corner_pixels_world', 'exp_level', 'exp_corner_pixels_data'),
+    (
+        ([[5, 5], [15, 15]], 0, [[5, 5], [15, 15]]),
+        # Multiscale level selection uses > rather than >= so use -1 and 21
+        # instead of 0 and 20 to ensure that the FOV is big enough.
+        ([[-1, -1], [21, 21]], 1, [[0, 0], [10, 10]]),
+        ([[-11, -11], [31, 31]], 2, [[0, 0], [5, 5]]),
+    ),
+)
+def test_update_draw_variable_fov_fixed_canvas_size(
+    corner_pixels_world, exp_level, exp_corner_pixels_data
+):
+    shapes = [(20, 20), (10, 10), (5, 5)]
+    data = [np.zeros(s) for s in shapes]
+    layer = Image(data, multiscale=True)
+    canvas_size_pixels = (10, 10)
+
+    layer._update_draw(
+        scale_factor=1,
+        corner_pixels_displayed=np.array(corner_pixels_world),
+        shape_threshold=canvas_size_pixels,
+    )
+
+    assert layer.data_level == exp_level
+    np.testing.assert_equal(layer.corner_pixels, exp_corner_pixels_data)
+
+
+@pytest.mark.parametrize(
+    ('canvas_size_pixels', 'exp_level', 'exp_corner_pixels_data'),
+    (
+        ([16, 16], 0, [[0, 0], [20, 20]]),
+        ([8, 8], 1, [[0, 0], [10, 10]]),
+        ([4, 4], 2, [[0, 0], [5, 5]]),
+    ),
+)
+def test_update_draw_variable_canvas_size_fixed_fov(
+    canvas_size_pixels, exp_level, exp_corner_pixels_data
+):
+    shapes = [(20, 20), (10, 10), (5, 5)]
+    data = [np.zeros(s) for s in shapes]
+    layer = Image(data, multiscale=True)
+    corner_pixels_world = np.array([[0, 0], [20, 20]])
+
+    layer._update_draw(
+        scale_factor=1,
+        corner_pixels_displayed=corner_pixels_world,
+        shape_threshold=canvas_size_pixels,
+    )
+
+    assert layer.data_level == exp_level
+    np.testing.assert_equal(layer.corner_pixels, exp_corner_pixels_data)

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -26,7 +26,6 @@ from ..utils.plane import SlicingPlane
 from ._image_constants import (
     ImageRendering,
     Interpolation,
-    Interpolation3D,
     Mode,
     VolumeDepiction,
 )
@@ -367,7 +366,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         self._set_colormap(colormap)
         self.contrast_limits = self._contrast_limits
         self._interpolation2d = Interpolation.NEAREST
-        self._interpolation3d = Interpolation3D.NEAREST
+        self._interpolation3d = Interpolation.NEAREST
         self.interpolation2d = interpolation2d
         self.interpolation3d = interpolation3d
         self.rendering = rendering
@@ -529,7 +528,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         vispy/gloo/glsl/misc/spatial_filters.frag
 
         Options include:
-        'bessel', 'bicubic', 'bilinear', 'blackman', 'catrom', 'gaussian',
+        'bessel', 'bicubic', 'linear', 'blackman', 'catrom', 'gaussian',
         'hamming', 'hanning', 'hermite', 'kaiser', 'lanczos', 'mitchell',
         'nearest', 'spline16', 'spline36'
 
@@ -572,6 +571,15 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
 
     @interpolation2d.setter
     def interpolation2d(self, value):
+        if value == 'bilinear':
+            value = 'linear'
+            warnings.warn(
+                trans._(
+                    "'bilinear' interpolation is deprecated. Please use 'linear' instead",
+                ),
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
         self._interpolation2d = Interpolation(value)
         self.events.interpolation2d(value=self._interpolation2d)
         self.events.interpolation(value=self._interpolation2d)
@@ -582,7 +590,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
 
     @interpolation3d.setter
     def interpolation3d(self, value):
-        self._interpolation3d = Interpolation3D(value)
+        self._interpolation3d = Interpolation(value)
         self.events.interpolation3d(value=self._interpolation3d)
         self.events.interpolation(value=self._interpolation3d)
 

--- a/napari/layers/image/image.py
+++ b/napari/layers/image/image.py
@@ -540,7 +540,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         """
         warnings.warn(
             trans._(
-                "Interpolation attribute is deprecated. Please use interpolation2d or interpolation3d",
+                "Interpolation attribute is deprecated since 0.4.17. Please use interpolation2d or interpolation3d",
             ),
             category=DeprecationWarning,
             stacklevel=2,
@@ -556,7 +556,7 @@ class _ImageBase(IntensityVisualizationMixin, Layer):
         """Set current interpolation mode."""
         warnings.warn(
             trans._(
-                "Interpolation setting is deprecated. Please use interpolation2d or interpolation3d",
+                "Interpolation setting is deprecated since 0.4.17. Please use interpolation2d or interpolation3d",
             ),
             category=DeprecationWarning,
             stacklevel=2,

--- a/napari/layers/labels/_labels_key_bindings.py
+++ b/napari/layers/labels/_labels_key_bindings.py
@@ -1,6 +1,9 @@
 import numpy as np
 
-from ...layers.utils.layer_utils import register_layer_action
+from ...layers.utils.layer_utils import (
+    register_layer_action,
+    register_layer_attr_action,
+)
 from ...utils.translations import trans
 from ._labels_constants import Mode
 from .labels import Labels
@@ -24,30 +27,43 @@ def register_label_action(description):
     return register_layer_action(Labels, description)
 
 
-@register_label_action(trans._("Activate the paint brush"))
+def register_label_mode_action(description):
+    return register_layer_attr_action(Labels, description, 'mode')
+
+
+@register_label_mode_action(trans._("Activate the paint brush"))
 def activate_paint_mode(layer: Labels):
     layer.mode = Mode.PAINT
 
 
-@register_label_action(trans._("Activate the fill bucket"))
+@register_label_mode_action(trans._("Activate the fill bucket"))
 def activate_fill_mode(layer: Labels):
     layer.mode = Mode.FILL
 
 
-@register_label_action(trans._('Pan/zoom mode'))
+@register_label_mode_action(trans._('Pan/zoom mode'))
 def activate_label_pan_zoom_mode(layer: Labels):
     layer.mode = Mode.PAN_ZOOM
 
 
-@register_label_action(trans._('Pick mode'))
+@register_label_mode_action(trans._('Pick mode'))
 def activate_label_picker_mode(layer: Labels):
     """Activate the label picker."""
     layer.mode = Mode.PICK
 
 
-@register_label_action(trans._("Activate the label eraser"))
+@register_label_mode_action(trans._("Activate the label eraser"))
 def activate_label_erase_mode(layer: Labels):
     layer.mode = Mode.ERASE
+
+
+labels_fun_to_mode = [
+    (activate_label_erase_mode, Mode.ERASE),
+    (activate_paint_mode, Mode.PAINT),
+    (activate_fill_mode, Mode.FILL),
+    (activate_label_picker_mode, Mode.PICK),
+    (activate_label_pan_zoom_mode, Mode.PAN_ZOOM),
+]
 
 
 @register_label_action(

--- a/napari/layers/labels/labels.py
+++ b/napari/layers/labels/labels.py
@@ -35,30 +35,6 @@ from ._labels_utils import (
     sphere_indices,
 )
 
-_REV_SHAPE_HELP = {
-    trans._('enter paint or fill mode to edit labels'): {
-        Mode.PAN_ZOOM,
-        Mode.TRANSFORM,
-    },
-    trans._('hold <space> to pan/zoom, click to pick a label'): {
-        Mode.PICK,
-        Mode.FILL,
-    },
-    trans._(
-        'hold <space> to pan/zoom, hold <shift> to toggle preserve_labels, hold <control> to fill, hold <alt> to erase, drag to paint a label'
-    ): {Mode.PAINT},
-    trans._('hold <space> to pan/zoom, drag to erase a label'): {Mode.ERASE},
-}
-
-# This avoid duplicating the trans._ help messages above
-# as some modes have the same help.
-# while most tooling will recognise identical messages,
-# this can lead to human error.
-_FWD_SHAPE_HELP = {}
-for t, modes in _REV_SHAPE_HELP.items():
-    for m in modes:
-        _FWD_SHAPE_HELP[m] = t
-
 
 class Labels(_ImageBase):
     """Labels (or segmentation) layer.
@@ -322,7 +298,6 @@ class Labels(_ImageBase):
         self._mode = Mode.PAN_ZOOM
         self._status = self.mode
         self._preserve_labels = False
-        self._help = trans._('enter paint or fill mode to edit labels')
 
         self._reset_history()
 
@@ -738,9 +713,7 @@ class Labels(_ImageBase):
         if not changed:
             return
 
-        self.help = _FWD_SHAPE_HELP[mode]
-
-        if mode in (Mode.PAINT, Mode.ERASE):
+        if mode in {Mode.PAINT, Mode.ERASE}:
             self.cursor_size = self._calculate_cursor_size()
 
         self.events.mode(mode=mode)

--- a/napari/layers/points/_points_key_bindings.py
+++ b/napari/layers/points/_points_key_bindings.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from napari.utils.notifications import show_info
 
-from ...layers.utils.layer_utils import register_layer_action
+from ...layers.utils.layer_utils import (
+    register_layer_action,
+    register_layer_attr_action,
+)
 from ...utils.translations import trans
 from ._points_constants import Mode
 from .points import Points
@@ -10,6 +13,10 @@ from .points import Points
 
 def register_points_action(description):
     return register_layer_action(Points, description)
+
+
+def register_points_mode_action(description):
+    return register_layer_attr_action(Points, description, 'mode')
 
 
 @Points.bind_key('Space')
@@ -29,19 +36,26 @@ def hold_to_pan_zoom(layer: Points):
         layer._set_highlight()
 
 
-@register_points_action(trans._('Add points'))
+@register_points_mode_action(trans._('Add points'))
 def activate_points_add_mode(layer: Points):
     layer.mode = Mode.ADD
 
 
-@register_points_action(trans._('Select points'))
+@register_points_mode_action(trans._('Select points'))
 def activate_points_select_mode(layer: Points):
     layer.mode = Mode.SELECT
 
 
-@register_points_action(trans._('Pan/zoom'))
+@register_points_mode_action(trans._('Pan/zoom'))
 def activate_points_pan_zoom_mode(layer: Points):
     layer.mode = Mode.PAN_ZOOM
+
+
+points_fun_to_mode = [
+    (activate_points_add_mode, Mode.ADD),
+    (activate_points_select_mode, Mode.SELECT),
+    (activate_points_pan_zoom_mode, Mode.PAN_ZOOM),
+]
 
 
 @Points.bind_key('Control-C')

--- a/napari/layers/points/points.py
+++ b/napari/layers/points/points.py
@@ -1282,12 +1282,8 @@ class Points(Layer):
         if mode == Mode.ADD:
             self.selected_data = set()
             self.interactive = True
-
-        if mode == Mode.PAN_ZOOM:
-            self.help = ''
+        elif mode == Mode.PAN_ZOOM:
             self.interactive = True
-        else:
-            self.help = trans._('hold <space> to pan/zoom')
 
         if mode != Mode.SELECT or old_mode != Mode.SELECT:
             self._selected_data_stored = set()

--- a/napari/layers/shapes/_shapes_key_bindings.py
+++ b/napari/layers/shapes/_shapes_key_bindings.py
@@ -1,6 +1,9 @@
 import numpy as np
 
-from ...layers.utils.layer_utils import register_layer_action
+from ...layers.utils.layer_utils import (
+    register_layer_action,
+    register_layer_attr_action,
+)
 from ...utils.translations import trans
 from ._shapes_constants import Box, Mode
 from ._shapes_mouse_bindings import _move
@@ -54,64 +57,82 @@ def register_shapes_action(description):
     return register_layer_action(Shapes, description)
 
 
-@register_shapes_action(trans._('Add rectangles'))
+def register_shapes_mode_action(description):
+    return register_layer_attr_action(Shapes, description, 'mode')
+
+
+@register_shapes_mode_action(trans._('Add rectangles'))
 def activate_add_rectangle_mode(layer: Shapes):
     """Activate add rectangle tool."""
     layer.mode = Mode.ADD_RECTANGLE
 
 
-@register_shapes_action(trans._('Add ellipses'))
+@register_shapes_mode_action(trans._('Add ellipses'))
 def activate_add_ellipse_mode(layer: Shapes):
     """Activate add ellipse tool."""
     layer.mode = Mode.ADD_ELLIPSE
 
 
-@register_shapes_action(trans._('Add lines'))
+@register_shapes_mode_action(trans._('Add lines'))
 def activate_add_line_mode(layer: Shapes):
     """Activate add line tool."""
     layer.mode = Mode.ADD_LINE
 
 
-@register_shapes_action(trans._('Add path'))
+@register_shapes_mode_action(trans._('Add path'))
 def activate_add_path_mode(layer: Shapes):
     """Activate add path tool."""
     layer.mode = Mode.ADD_PATH
 
 
-@register_shapes_action(trans._('Add polygons'))
+@register_shapes_mode_action(trans._('Add polygons'))
 def activate_add_polygon_mode(layer: Shapes):
     """Activate add polygon tool."""
     layer.mode = Mode.ADD_POLYGON
 
 
-@register_shapes_action(trans._('Select vertices'))
+@register_shapes_mode_action(trans._('Select vertices'))
 def activate_direct_mode(layer: Shapes):
     """Activate vertex selection tool."""
     layer.mode = Mode.DIRECT
 
 
-@register_shapes_action(trans._('Select shapes'))
+@register_shapes_mode_action(trans._('Select shapes'))
 def activate_select_mode(layer: Shapes):
     """Activate shape selection tool."""
     layer.mode = Mode.SELECT
 
 
-@register_shapes_action(trans._('Pan/Zoom'))
+@register_shapes_mode_action(trans._('Pan/Zoom'))
 def activate_shape_pan_zoom_mode(layer: Shapes):
     """Activate pan and zoom mode."""
     layer.mode = Mode.PAN_ZOOM
 
 
-@register_shapes_action(trans._('Insert vertex'))
+@register_shapes_mode_action(trans._('Insert vertex'))
 def activate_vertex_insert_mode(layer: Shapes):
     """Activate vertex insertion tool."""
     layer.mode = Mode.VERTEX_INSERT
 
 
-@register_shapes_action(trans._('Remove vertex'))
+@register_shapes_mode_action(trans._('Remove vertex'))
 def activate_vertex_remove_mode(layer: Shapes):
     """Activate vertex deletion tool."""
     layer.mode = Mode.VERTEX_REMOVE
+
+
+shapes_fun_to_mode = [
+    (activate_add_rectangle_mode, Mode.ADD_RECTANGLE),
+    (activate_add_ellipse_mode, Mode.ADD_ELLIPSE),
+    (activate_add_line_mode, Mode.ADD_LINE),
+    (activate_add_path_mode, Mode.ADD_PATH),
+    (activate_add_polygon_mode, Mode.ADD_POLYGON),
+    (activate_direct_mode, Mode.DIRECT),
+    (activate_select_mode, Mode.SELECT),
+    (activate_shape_pan_zoom_mode, Mode.PAN_ZOOM),
+    (activate_vertex_insert_mode, Mode.VERTEX_INSERT),
+    (activate_vertex_remove_mode, Mode.VERTEX_REMOVE),
+]
 
 
 @register_shapes_action(trans._('Copy any selected shapes'))

--- a/napari/layers/shapes/shapes.py
+++ b/napari/layers/shapes/shapes.py
@@ -30,14 +30,7 @@ from ..utils.interactivity_utils import nd_line_segment_to_displayed_data_ray
 from ..utils.layer_utils import _FeatureTable
 from ..utils.text_manager import TextManager
 from ._shape_list import ShapeList
-from ._shapes_constants import (
-    BACKSPACE,
-    Box,
-    ColorMode,
-    Mode,
-    ShapeType,
-    shape_classes,
-)
+from ._shapes_constants import Box, ColorMode, Mode, ShapeType, shape_classes
 from ._shapes_mouse_bindings import (
     add_ellipse,
     add_line,
@@ -60,41 +53,6 @@ from ._shapes_utils import (
 )
 
 DEFAULT_COLOR_CYCLE = np.array([[1, 0, 1, 1], [0, 1, 0, 1]])
-
-
-_REV_SHAPE_HELP = {
-    trans._('hold <space> to pan/zoom'): {
-        Mode.VERTEX_INSERT,
-        Mode.VERTEX_REMOVE,
-        Mode.ADD_RECTANGLE,
-        Mode.ADD_ELLIPSE,
-        Mode.ADD_LINE,
-        Mode.TRANSFORM,
-    },
-    trans._(
-        'hold <space> to pan/zoom, press <esc>, or double click to finish drawing'
-    ): {
-        Mode.ADD_PATH,
-        Mode.ADD_POLYGON,
-    },
-    trans._(
-        'hold <space> to pan/zoom, press <{BACKSPACE}> to remove selected',
-        BACKSPACE=BACKSPACE,
-    ): {Mode.SELECT, Mode.DIRECT},
-    trans._('enter a selection mode to edit shape properties'): {
-        Mode.PAN_ZOOM
-    },
-}
-
-
-# This avoid duplicating the trans._ help messages above
-# as some modes have the same help.
-# while most tooling will recognise identical messages,
-# this can lead to human error.
-_FWD_SHAPE_HELP = {}
-for t, modes in _REV_SHAPE_HELP.items():
-    for m in modes:
-        _FWD_SHAPE_HELP[m] = t
 
 
 class Shapes(Layer):
@@ -1626,7 +1584,6 @@ class Shapes(Layer):
 
     @mode.setter
     def mode(self, mode: Union[str, Mode]):
-        old_mode = self._mode
         mode, changed = self._mode_setter_helper(mode, Mode)
         if not changed:
             return
@@ -1640,8 +1597,6 @@ class Shapes(Layer):
 
         old_mode = self._mode
         self._mode = mode
-
-        self.help = _FWD_SHAPE_HELP[mode]
 
         draw_modes = {
             Mode.SELECT,

--- a/napari/layers/utils/_tests/test_link_layers.py
+++ b/napari/layers/utils/_tests/test_link_layers.py
@@ -20,7 +20,7 @@ BASE_ATTRS = {
 IM_ATTRS = {
     'rendering': 'translucent',
     'iso_threshold': 0.34,
-    'interpolation2d': 'bilinear',
+    'interpolation2d': 'linear',
     'contrast_limits': [0.25, 0.75],
     'gamma': 0.5,
 }

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import functools
+import inspect
 import warnings
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -59,6 +61,69 @@ def register_layer_action(keymapprovider, description: str, shortcuts=None):
         return func
 
     return _inner
+
+
+def register_layer_attr_action(
+    keymapprovider,
+    description: str,
+    attribute_name: str,
+    shortcuts=None,
+):
+    """
+    Convenient decorator to register an action with the current Layers.
+    This will get and restore attribute from function first argument.
+
+    It will use the function name as the action name. We force the description
+    to be given instead of function docstring for translation purpose.
+
+    Parameters
+    ----------
+    keymapprovider : KeymapProvider
+        class on which to register the keybindings – this will typically be
+        the instance in focus that will handle the keyboard shortcut.
+    description : str
+        The description of the action, this will typically be translated and
+        will be what will be used in tooltips.
+    attribute_name : str
+        The name of the attribute to be restored if key is hold over `get_settings().get_settings().application.hold_button_delay.
+    shortcuts : str | List[str]
+        Shortcut to bind by default to the action we are registering.
+
+    Returns
+    -------
+    function:
+        Actual decorator to apply to a function. Given decorator returns the
+        function unmodified to allow decorator stacking.
+
+    """
+
+    def _handle(func):
+        sig = inspect.signature(func)
+        try:
+            first_variable_name = next(iter(sig.parameters))
+        except StopIteration:
+            raise RuntimeError(
+                "If actions has no arguments there is no way to know what to set the attribute to."
+            )
+
+        @functools.wraps(func)
+        def _wrapper(*args, **kwargs):
+            if args:
+                obj = args[0]
+            else:
+                obj = kwargs[first_variable_name]
+            prev_mode = getattr(obj, attribute_name)
+            func(*args, **kwargs)
+
+            def _callback():
+                setattr(obj, attribute_name, prev_mode)
+
+            return _callback
+
+        register_layer_action(keymapprovider, description, shortcuts)(_wrapper)
+        return func
+
+    return _handle
 
 
 def _nanmin(array):

--- a/napari/layers/utils/layer_utils.py
+++ b/napari/layers/utils/layer_utils.py
@@ -501,7 +501,7 @@ def compute_multiscale_level(
     # Scale shape by downsample factors
     scaled_shape = requested_shape / downsample_factors
 
-    # Find the highest resolution level allowed
+    # Find the highest level (lowest resolution) allowed
     locations = np.argwhere(np.all(scaled_shape > shape_threshold, axis=1))
     if len(locations) > 0:
         level = locations[-1][0]

--- a/napari/layers/utils/text_manager.py
+++ b/napari/layers/utils/text_manager.py
@@ -144,7 +144,7 @@ class TextManager(EventedModel):
         """
         warnings.warn(
             trans._(
-                'TextManager.refresh_text is deprecated. Use TextManager.refresh instead.'
+                'TextManager.refresh_text is deprecated since 0.4.16. Use TextManager.refresh instead.'
             ),
             DeprecationWarning,
             stacklevel=2,
@@ -164,7 +164,7 @@ class TextManager(EventedModel):
         """
         warnings.warn(
             trans._(
-                'TextManager.add is deprecated. Use TextManager.apply instead.'
+                'TextManager.add is deprecated since 0.4.16. Use TextManager.apply instead.'
             ),
             DeprecationWarning,
             stacklevel=2,
@@ -363,7 +363,9 @@ class TextManager(EventedModel):
 
 def _warn_about_deprecated_text_parameter():
     warnings.warn(
-        trans._('text is a deprecated parameter. Use string instead.'),
+        trans._(
+            'text is a deprecated parameter since 0.4.16. Use string instead.'
+        ),
         DeprecationWarning,
         stacklevel=2,
     )
@@ -371,7 +373,9 @@ def _warn_about_deprecated_text_parameter():
 
 def _warn_about_deprecated_properties_parameter():
     warnings.warn(
-        trans._('properties is a deprecated parameter. Use features instead.'),
+        trans._(
+            'properties is a deprecated parameter since 0.4.16. Use features instead.'
+        ),
         DeprecationWarning,
         stacklevel=2,
     )
@@ -379,7 +383,9 @@ def _warn_about_deprecated_properties_parameter():
 
 def _warn_about_deprecated_n_text_parameter():
     warnings.warn(
-        trans._('n_text is a deprecated parameter. Use features instead.'),
+        trans._(
+            'n_text is a deprecated parameter since 0.4.16. Use features instead.'
+        ),
         DeprecationWarning,
         stacklevel=2,
     )
@@ -387,7 +393,9 @@ def _warn_about_deprecated_n_text_parameter():
 
 def _warn_about_deprecated_values_parameter():
     warnings.warn(
-        trans._('values is a deprecated parameter. Use string instead.'),
+        trans._(
+            'values is a deprecated parameter since 0.4.16. Use string instead.'
+        ),
         DeprecationWarning,
         stacklevel=2,
     )

--- a/napari/plugins/hub.py
+++ b/napari/plugins/hub.py
@@ -44,6 +44,21 @@ def hub_plugin_info(
     except error.HTTPError:
         return None, False
 
+    # If the napari hub returns an info dict missing the required keys,
+    # simply return None, False like the above except
+    if (
+        not {
+            'name',
+            'version',
+            'authors',
+            'summary',
+            'license',
+            'project_site',
+        }
+        <= info.keys()
+    ):
+        return None, False
+
     version = info["version"]
     norm_name = normalized_name(info["name"])
     is_available_in_conda_forge = True

--- a/napari/plugins/utils.py
+++ b/napari/plugins/utils.py
@@ -1,6 +1,9 @@
+import os.path as osp
 import re
+from enum import IntFlag
 from fnmatch import fnmatch
-from typing import Dict, Set, Tuple, Union
+from functools import lru_cache
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from npe2 import PluginManifest
 
@@ -9,14 +12,104 @@ from napari.settings import get_settings
 from . import _npe2, plugin_manager
 
 
-def get_preferred_reader(_path):
-    """Return preferred reader for _path from settings, if one exists."""
+class MatchFlag(IntFlag):
+    NONE = 0
+    SET = 1
+    ANY = 2
+    STAR = 4
+
+
+@lru_cache
+def score_specificity(pattern: str) -> Tuple[bool, int, List[MatchFlag]]:
+    """Score an fnmatch pattern, with higher specificities having lower scores.
+
+    Absolute paths have highest specificity,
+    followed by paths with the most nesting,
+    then by path segments with the least ambiguity.
+
+    Parameters
+    ----------
+    pattern : str
+        Pattern to score.
+
+    Returns
+    -------
+    relpath : boolean
+        Whether the path is relative or absolute.
+    nestedness : negative int
+        Level of nestedness of the path, lower is deeper.
+    score : List[MatchFlag]
+        Path segments scored by ambiguity, higher score is higher ambiguity.
+    """
+    pattern = osp.normpath(pattern)
+
+    segments = pattern.split(osp.sep)
+    score: List[MatchFlag] = []
+    ends_with_star = False
+
+    def add(match_flag):
+        score[-1] |= match_flag
+
+    # built-in fnmatch does not allow you to escape meta-characters
+    # so we don't need to handle them :)
+    for segment in segments:
+        # collapse foo/*/*/*.bar or foo*/*.bar but not foo*bar/*.baz
+        if segment and not (ends_with_star and segment.startswith('*')):
+            score.append(MatchFlag.NONE)
+
+        if '*' in segment:
+            add(MatchFlag.STAR)
+        if '?' in segment:
+            add(MatchFlag.ANY)
+        if '[' in segment and ']' in segment[segment.index('[') :]:
+            add(MatchFlag.SET)
+
+        ends_with_star = segment.endswith('*')
+
+    return not osp.isabs(pattern), 1 - len(score), score
+
+
+def _get_preferred_readers(path: str) -> Iterable[Tuple[str, str]]:
+    """Given filepath, find matching readers from preferences.
+
+    Parameters
+    ----------
+    path : str
+        Path of the file.
+
+    Returns
+    -------
+    filtered_preferences : Iterable[Tuple[str, str]]
+        Filtered patterns and their corresponding readers.
+    """
     reader_settings = get_settings().plugins.extension2reader
-    for pattern, reader in reader_settings.items():
-        # TODO: we return the first one we find - more work should be done here
-        # in case other patterns would match - do we return the most specific?
-        if fnmatch(_path, pattern):
-            return reader
+
+    return filter(lambda kv: fnmatch(path, kv[0]), reader_settings.items())
+
+
+def get_preferred_reader(path: str) -> Optional[str]:
+    """Given filepath, find the best matching reader from the preferences.
+
+    Parameters
+    ----------
+    path : str
+        Path of the file.
+
+    Returns
+    -------
+    reader : str or None
+        Best matching reader, if found.
+    """
+    readers = sorted(
+        _get_preferred_readers(path), key=lambda kv: score_specificity(kv[0])
+    )
+
+    if readers:
+        preferred = readers[0]
+        _, reader = preferred
+        return reader
+
+    return None
 
 
 def get_potential_readers(filename: str) -> Dict[str, str]:

--- a/napari/qt/progress.py
+++ b/napari/qt/progress.py
@@ -4,7 +4,7 @@ from ..utils.translations import trans
 
 warnings.warn(
     trans._(
-        'progress has moved from qt. Use `from napari.utils import progress` instead',
+        'progress has moved from qt since 0.4.11. Use `from napari.utils import progress` instead',
         deferred=True,
     ),
     category=FutureWarning,

--- a/napari/settings/_application.py
+++ b/napari/settings/_application.py
@@ -162,6 +162,13 @@ class ApplicationSettings(EventedModel):
             "Ask for confirmation before closing a napari window or application (all napari windows).",
         ),
     )
+    hold_button_delay: float = Field(
+        default=0.5,
+        title=trans._("Delay to treat button as hold in seconds"),
+        description=trans._(
+            "This affects certain actions where a short press and a long press have different behaviors, such as changing the mode of a layer permanently or only during the long press."
+        ),
+    )
 
     @validator('window_state')
     def _validate_qbtye(cls, v):

--- a/napari/utils/_injection/__init__.py
+++ b/napari/utils/_injection/__init__.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from inspect import isgeneratorfunction, signature
+from inspect import isgeneratorfunction, signature, unwrap
 from typing import Any, Callable, Dict, Optional, TypeVar
 
 from typing_extensions import get_type_hints
@@ -72,7 +72,7 @@ def inject_napari_dependencies(func: Callable[..., T]) -> Callable[..., T]:
     Callable
         A function with napari dependencies injected
     """
-    if not func.__code__.co_argcount and 'return' not in getattr(
+    if not unwrap(func).__code__.co_argcount and 'return' not in getattr(
         func, '__annotations__', {}
     ):
         return func

--- a/napari/utils/_magicgui.py
+++ b/napari/utils/_magicgui.py
@@ -358,7 +358,37 @@ def add_layer_to_viewer(gui, result: Any, return_type: Type[Layer]) -> None:
     ...     return napari.layers.Image(np.random.rand(64, 64))
 
     """
+    add_layers_to_viewer(gui, [result], List[return_type])
+
+
+def add_layers_to_viewer(gui, result: Any, return_type: List[Layer]) -> None:
+    """Show a magicgui result in the viewer.
+
+    Parameters
+    ----------
+    gui : MagicGui or QWidget
+        The instantiated MagicGui widget.  May or may not be docked in a
+        dock widget.
+    result : Any
+        The result of the function call.
+    return_type : type
+        The return annotation that was used in the decorated function.
+
+    Examples
+    --------
+    This allows the user to do this, and add the resulting layer to the viewer.
+
+    >>> @magicgui
+    ... def make_layer() -> List[napari.layers.Layer]:
+    ...     return napari.layers.Image(np.random.rand(64, 64))
+
+    """
     from ..utils._injection._processors import _add_layer_to_viewer
 
-    if result is not None and (viewer := find_viewer_ancestor(gui)):
-        _add_layer_to_viewer(result, viewer=viewer, source={'widget': gui})
+    viewer = find_viewer_ancestor(gui)
+    if not viewer:
+        return
+
+    for item in result:
+        if item is not None:
+            _add_layer_to_viewer(item, viewer=viewer, source={'widget': gui})

--- a/napari/utils/_proxies.py
+++ b/napari/utils/_proxies.py
@@ -43,7 +43,9 @@ class PublicOnlyProxy(wrapt.ObjectProxy, Generic[_T]):
     __wrapped__: _T
 
     def __getattr__(self, name: str):
-        if name.startswith("_"):
+        if name.startswith("_") and not (
+            name.startswith('__') and name.endswith('__')
+        ):
             # allow napari to access private attributes and get an non-proxy
             frame = sys._getframe(1) if hasattr(sys, "_getframe") else None
             if frame.f_code.co_filename.startswith(misc.ROOT_DIR):

--- a/napari/utils/_tests/test_translations.py
+++ b/napari/utils/_tests/test_translations.py
@@ -379,13 +379,48 @@ def test_bundle_exceptions(trans):
         trans._dnpgettext()
 
 
-def test_deepcopy():
-    """see https://github.com/napari/napari/issues/2911
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            'msgid': 'huhu',
+        },
+        {
+            'msgid': 'Convert to {dtype}',
+            'dtype': 'uint16',
+        },
+        {
+            'msgid': 'Convert to {dtype}',
+            'dtype': 'uint16',
+            'deferred': True,
+        },
+        {
+            'msgid': 'Convert to {dtype}',
+            'dtype': 'uint16',
+            'deferred': False,
+        },
+        {
+            'msgid': 'Convert to {dtype}',
+            'msgid_plural': 'Convert to {dtype}s',
+            'n': 1,
+            'dtype': 'uint16',
+        },
+        {
+            'msgid': 'Convert to {dtype}',
+            'msgid_plural': 'Convert to {dtype}s',
+            'n': 2,
+            'dtype': 'uint16',
+        },
+    ],
+)
+def test_deepcopy(kwargs):
+    """Object containing translation strings can't be deep-copied.
 
-    Object containing translation strings can't bee deep-copied.
+    See:
+      - https://github.com/napari/napari/issues/2911
+      - https://github.com/napari/napari/issues/4736
     """
-
-    t = TranslationString(msgid='huhu')
+    t = TranslationString(**kwargs)
     u = deepcopy(t)
     assert t is not u
     assert t == u

--- a/napari/utils/events/containers/_selectable_list.py
+++ b/napari/utils/events/containers/_selectable_list.py
@@ -110,7 +110,7 @@ class SelectableEventedList(Selectable[_T], EventedList[_T]):
         """
         # this is just here for now to support the old layerlist API
         warnings.warn(
-            "move_selected is deprecated. Please use layers.move_multiple "
+            "move_selected is deprecated since 0.4.16. Please use layers.move_multiple "
             "with layers.selection instead.",
             FutureWarning,
             stacklevel=2,

--- a/napari/utils/settings/__init__.py
+++ b/napari/utils/settings/__init__.py
@@ -5,7 +5,7 @@ from ..translations import trans
 
 warnings.warn(
     trans._(
-        "'napari.utils.settings' has moved to 'napari.settings'. This will raise an ImportError in a future version",
+        "'napari.utils.settings' has moved to 'napari.settings' in 0.4.11. This will raise an ImportError in a future version",
         deferred=True,
     ),
     FutureWarning,

--- a/napari/utils/theme.py
+++ b/napari/utils/theme.py
@@ -164,7 +164,7 @@ def template(css: str, **theme):
     return css
 
 
-def get_system_theme():
+def get_system_theme() -> str:
     """Return the system default theme, either 'dark', or 'light'."""
     try:
         name = darkdetect.theme().lower()

--- a/napari/utils/translations.py
+++ b/napari/utils/translations.py
@@ -167,6 +167,10 @@ class TranslationString(str):
     def __deepcopy__(self, memo):
         from copy import deepcopy
 
+        kwargs = deepcopy(self._kwargs)
+        # Remove `n` from `kwargs` added in the initializer
+        # See https://github.com/napari/napari/issues/4736
+        kwargs.pop("n")
         return TranslationString(
             domain=self._domain,
             msgctxt=self._msgctxt,
@@ -174,7 +178,7 @@ class TranslationString(str):
             msgid_plural=self._msgid_plural,
             n=self._n,
             deferred=self._deferred,
-            kwargs=deepcopy(self._kwargs),
+            **kwargs,
         )
 
     def __new__(

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ install_requires =
     toolz>=0.10.0
     tqdm>=4.56.0
     typing_extensions
-    vispy>=0.10.0,<0.11
+    vispy>=0.11.0,<0.12
     wrapt>=1.11.1
 
 [options.package_data]

--- a/tools/string_list.json
+++ b/tools/string_list.json
@@ -29,7 +29,30 @@
       "plugins.io",
       "utils.notifications",
       "view_layers",
-      "viewer"
+      "viewer",
+      "__version__",
+      "components",
+      "experimental",
+      "layers",
+      "qt",
+      "types",
+      "utils",
+      "gui_qt",
+      "run",
+      "save_layers",
+      "utils",
+      "sys_info",
+      "notification_manager",
+      "view_image",
+      "view_labels",
+      "view_path",
+      "view_points",
+      "view_shapes",
+      "view_surface",
+      "view_tracks",
+      "view_vectors",
+      "Viewer",
+      "current_viewer"
     ],
     "napari/_event_loop.py": [],
     "napari/_qt/__init__.py": [
@@ -40,7 +63,26 @@
       "plugins"
     ],
     "napari/_qt/_constants.py": [],
-    "napari/_qt/containers/__init__.py": [],
+    "napari/_qt/code_syntax_highlight.py": [
+      "monospace",
+      "color",
+      "#{style['color']}",
+      "bgcolor",
+      "bgcolor",
+      "bold",
+      "italic",
+      "underline"
+    ],
+    "napari/_qt/containers/__init__.py": [
+      "create_model",
+      "create_view",
+      "QtLayerList",
+      "QtLayerListModel",
+      "QtListModel",
+      "QtListView",
+      "QtNodeTreeModel",
+      "QtNodeTreeView"
+    ],
     "napari/_qt/containers/_base_item_model.py": [
       "ItemType",
       "_root"
@@ -152,7 +194,11 @@
       "icon",
       "info",
       "none",
-      "warning"
+      "warning",
+      "opacity",
+      "geometry",
+      "QPushButton{padding: 4px 12px 4px 12px; font-size: 11px;min-height: 18px; border-radius: 0;}",
+      "python"
     ],
     "napari/_qt/dialogs/qt_plugin_dialog.py": [
       "-c",
@@ -198,14 +244,39 @@
       "uninstall",
       "url",
       "version",
-      "warning_icon"
+      "warning_icon",
+      "CONDA_PINNED_PACKAGES",
+      "&{env.value('CONDA_PINNED_PACKAGES')}",
+      "CONDA_PINNED_PACKAGES",
+      "napari={napari_version}{system_pins}",
+      "nt",
+      "TEMP",
+      "TMP",
+      "TEMP",
+      "USERPROFILE",
+      "HOME",
+      "~",
+      "USERPROFILE",
+      "~",
+      "shim",
+      "shim",
+      "warning",
+      "#E3B617",
+      "{pkg_name} {project_info.summary}",
+      "latest_version",
+      "=={item.latest_version}",
+      "1.0",
+      "shim",
+      "napari_hub"
     ],
     "napari/_qt/dialogs/qt_plugin_report.py": [
       "QtCopyToClipboardButton",
       "github.com",
       "pluginInfo",
       "url",
-      "{meta.get(\"url\")}/issues/new?&body={err}"
+      "{meta.get(\"url\")}/issues/new?&body={err}",
+      "python",
+      "NoColor"
     ],
     "napari/_qt/dialogs/qt_reader_dialog.py": [
       "Choose reader",
@@ -709,7 +780,6 @@
       "_QtMainWindow"
     ],
     "napari/_qt/widgets/qt_welcome.py": [
-      "Ctrl+Alt+/",
       "Ctrl+O",
       "QEvent",
       "drag",
@@ -964,8 +1034,6 @@
     "napari/benchmarks/benchmark_qt_viewer.py": [],
     "napari/benchmarks/benchmark_qt_viewer_image.py": [],
     "napari/benchmarks/benchmark_qt_viewer_labels.py": [
-      "Event",
-      "is_dragging",
       "paint"
     ],
     "napari/benchmarks/benchmark_shapes_layer.py": [
@@ -1016,9 +1084,7 @@
       "bottom_center",
       "crosshair"
     ],
-    "napari/components/_viewer_key_bindings.py": [
-      "napari:"
-    ],
+    "napari/components/_viewer_key_bindings.py": [],
     "napari/components/_viewer_mouse_bindings.py": [
       "Control"
     ],
@@ -1939,7 +2005,6 @@
       "builtins",
       "index",
       "name",
-      "napari_write_{layer_type}",
       "properties",
       "rectangle",
       "shape-type",
@@ -1960,7 +2025,6 @@
     "napari/plugins/_plugin_manager.py": [
       "`napari_experimental_provide_dock_widget`",
       "`napari_experimental_provide_function`",
-      "builtins",
       "data",
       "display_name",
       "dock",
@@ -1972,8 +2036,6 @@
       "napari.plugin",
       "napari_provide_sample_data",
       "plugin",
-      "scikit-image",
-      "skimage",
       ".{extension}",
       ".{ext}",
       "_extension2{type_}",
@@ -2076,7 +2138,6 @@
       "{url}{page}"
     ],
     "napari/plugins/utils.py": [
-      "builtins",
       "napari_get_reader"
     ],
     "napari/qt/__init__.py": [],
@@ -2180,7 +2241,6 @@
       "VectorsData",
       "dask.array.Array",
       "zarr.Array",
-      "{layer_name.title()}Data",
       "_DType_co"
     ],
     "napari/utils/__init__.py": [],
@@ -2206,8 +2266,6 @@
     ],
     "napari/utils/_magicgui.py": [
       "Data",
-      "add_{layer_type}",
-      "name",
       "native",
       "parent",
       "_qt_viewer",
@@ -2783,7 +2841,6 @@
     ],
     "napari/utils/notebook_display.py": [
       "png",
-      "<img src=\"{url}\"></img>",
       "data:image/png;base64,",
       "utf-8"
     ],
@@ -2917,7 +2974,6 @@
       ": {status_format(value[0])}",
       "[",
       "]",
-      "{name} {full_coord}",
       "{value:0.3g}"
     ],
     "napari/utils/temporary_file.py": [],


### PR DESCRIPTION
# Description
<!-- What does this pull request (PR) do? Why is it necessary? -->
<!-- Tell us about your new feature, improvement, or fix! -->
<!-- If your change includes user interface changes, please add an image, or an animation "An image is worth a thousand words!" -->
<!-- You can use https://www.cockos.com/licecap/ or similar to create animations -->
I've added a benchmark to check for regressions when switching to updating the mesh with every slice event. 

Based on my understanding, calling `refresh` should trigger both `on_data_change` _and_ `set_view_slice`. This means that `refresh` should encompass the mesh code in both locations and be as close to apples to apples as possible. 

That said, I'm not certain whether `refresh` should be called more than once in order to capture the additional burden of recalculating the mesh with every slice. I believe that in the old code, there was basically a check to see if anything had changed and if not, the mesh wasn't recalculated. This would mean that running refresh multiple times on the old code should be less computationally expensive than the new code _unless_ the reduction to only generate the mesh in the slice subset is sufficiently efficient. 

TLDR - I benchmarked against calling refresh in the test function once, and again with three consecutive calls to refresh.

**RESULTS:**


**call refresh once**
```
**old code**
[100.00%] ··· ======== =============
               param1               
              -------- -------------
                 16     2.81±0.02ms 
                 64     4.67±0.09ms 
                256      10.2±0.1ms 
                1024     36.3±0.8ms 
                4096     74.6±0.2ms 
               16384      110±1ms   
               65536      250±3ms   
              ======== =============


**new code**
[100.00%] ··· ======== =============
               param1               
              -------- -------------
                 16     2.93±0.03ms 
                 64     4.70±0.06ms 
                256      10.5±0.1ms 
                1024     38.1±0.9ms 
                4096     75.8±0.4ms 
               16384     122±0.8ms  
               65536      298±2ms   
              ======== =============
```

**call refresh 3 times**
```
**old code**
[100.00%] ··· ======== =============
               param1               
              -------- -------------
                 16      8.30±0.1ms 
                 64     13.9±0.07ms 
                256      31.2±0.3ms 
                1024     105±0.6ms  
                4096      216±1ms   
               16384      326±6ms   
               65536      756±9ms   
              ======== =============

**new code**
[100.00%] ··· ======== =============
               param1               
              -------- -------------
                 16     8.63±0.02ms 
                 64     14.3±0.09ms 
                256      32.0±0.2ms 
                1024     106±0.7ms  
                4096      224±2ms   
               16384     358±0.8ms  
               65536      896±4ms   
              ======== =============
```   



## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug-fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# References
<!-- What resources, documentation, and guides were used in the creation of this PR? -->
<!-- If this is a bug-fix or otherwise resolves an issue, reference it here with "closes #(issue)" -->

I added this benchmark as a qt benchmark because otherwise, the benchmark wasn't getting into `on_data_change`. It was strange because when I ran the same commands through pytest, I could have gotten away with not instantiating the viewer (I think). If there is a better approach, I'm happy to hear it! 


# How has this been tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] example: the test suite for my feature covers cases x, y, and z
- [ ] example: all tests pass with my change
- [ ] example: I check if my changes works with both PySide and PyQt backends
      as there are small differences between the two Qt bindings.  

## Final checklist:
- [x] My PR is the minimum possible work for the desired functionality
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If I included new strings, I have used `trans.` to make them localizable.
      For more information see our [translations guide](https://napari.org/developers/translations.html).
